### PR TITLE
fix: correct sucessfully to successfully typo in echo message

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -15,6 +15,6 @@ fi
 echo get subscribe
 wget $subscribeclash -O ./clash.yaml
 wget $subscribeV2ray -O ./v2ray.txt
-echo get subscribe sucessfully
+echo get subscribe successfully
 echo hope you have a good day~
 echo bye~


### PR DESCRIPTION
Fix typo: sucessfully to successfully in run.sh (line 18).

User-visible echo message displayed after subscription.

Changes:
- 1 file, 1 line change